### PR TITLE
Show an error if there's no token returned

### DIFF
--- a/src/steps/send_challenge_sep10.js
+++ b/src/steps/send_challenge_sep10.js
@@ -3,7 +3,7 @@ module.exports = {
   instruction:
     "We need to send the signed SEP10 challenge back to the server to get a JWT token to authenticate our stellar account with future actions",
   action: "Send signed response back to server",
-  execute: async function(state, { log }) {
+  execute: async function(state, { log, error }) {
     const AUTH_URL = Config.get("AUTH_SERVER_URL");
     const transaction = state.signed_challenge_tx;
     const params = new URLSearchParams();
@@ -14,6 +14,9 @@ module.exports = {
     const json = await response.json();
     log("POST /auth response");
     log(json);
+    if (!state.token) {
+      error("No token returned from /auth");
+    }
     state.token = json.token;
   }
 };


### PR DESCRIPTION
Right now we expect the happy path, but better to fail early.  Show an error in case something fails, but we should actually bail in the future.