### PR TITLE
Use json instead of urlencoded body

### DIFF
--- a/src/steps/send_challenge_sep10.js
+++ b/src/steps/send_challenge_sep10.js
@@ -6,11 +6,18 @@ module.exports = {
   execute: async function(state, { log, error }) {
     const AUTH_URL = Config.get("AUTH_SERVER_URL");
     const transaction = state.signed_challenge_tx;
-    const params = new URLSearchParams();
-    params.set("transaction", transaction.toEnvelope().toXDR("base64"));
+    const params = {
+      transaction: transaction.toEnvelope().toXDR("base64")
+    };
     log("POST /auth request with params:");
-    log(params.toString());
-    const response = await fetch(AUTH_URL, { method: "POST", body: params });
+    log(params);
+    const response = await fetch(AUTH_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(params)
+    });
     const json = await response.json();
     log("POST /auth response");
     log(json);


### PR DESCRIPTION
URLEncoding can cause more problems then its worth.  I'd like to remove it from the SEP altogether, but in the meantime this might help us understand if the URLEncoding is causing peoples issues.

If we don't remove it from the sep we should figure out a way to ensure this client tests both paths