### PR TITLE
Expect hex hash

### DIFF
--- a/src/steps/get_withdraw_unauth.js
+++ b/src/steps/get_withdraw_unauth.js
@@ -11,7 +11,7 @@ module.exports = {
     const USER_SK = Config.get("USER_SK");
     const pk = StellarSDK.Keypair.fromSecret(USER_SK).publicKey();
     const BRIDGE_URL = Config.get("BRIDGE_URL");
-    const withdrawType = "bank_account";
+    const withdrawType = "cash";
     const params = {
       type: withdrawType,
       asset_code: ASSET_CODE,

--- a/src/steps/get_withdraw_unauth.js
+++ b/src/steps/get_withdraw_unauth.js
@@ -11,7 +11,7 @@ module.exports = {
     const USER_SK = Config.get("USER_SK");
     const pk = StellarSDK.Keypair.fromSecret(USER_SK).publicKey();
     const BRIDGE_URL = Config.get("BRIDGE_URL");
-    const withdrawType = "cash";
+    const withdrawType = "bank_account";
     const params = {
       type: withdrawType,
       asset_code: ASSET_CODE,

--- a/src/steps/send_stellar_transaction.js
+++ b/src/steps/send_stellar_transaction.js
@@ -1,5 +1,6 @@
 const StellarSdk = require("stellar-sdk");
 const Config = require("../config");
+const get = require("../util/get");
 
 module.exports = {
   instruction:
@@ -16,8 +17,7 @@ module.exports = {
     });
     const server = new StellarSdk.Server(HORIZON_URI);
     const account = await server.loadAccount(pk);
-    const fee = await server.fetchBaseFee();
-
+    const feeStats = await get(`${HORIZON_URI}/fee_stats`);
     let memo;
     try {
       const memoType = {
@@ -35,7 +35,9 @@ module.exports = {
       );
     }
 
-    const transaction = new StellarSdk.TransactionBuilder(account, { fee })
+    const transaction = new StellarSdk.TransactionBuilder(account, {
+      fee: feeStats.p70_accepted_fee
+    })
       .addOperation(
         StellarSdk.Operation.payment({
           destination: state.anchors_stellar_address,

--- a/src/steps/send_stellar_transaction.js
+++ b/src/steps/send_stellar_transaction.js
@@ -1,31 +1,11 @@
 const StellarSdk = require("stellar-sdk");
 const Config = require("../config");
 
-const generateMemo = (stellar_memo, stellar_memo_type) => {
-  let memo = null;
-  switch (stellar_memo_type) {
-    case "text":
-      memo = StellarSdk.Memo.text(stellar_memo);
-      break;
-    case "hash":
-      let memoBuffer = Buffer.alloc(32);
-      let anchorMemoBuffer = Buffer.from(stellar_memo);
-      // Sometimes the memo returned is smaller than 32 bytes so we need to pad to exactly 32
-      anchorMemoBuffer.copy(memoBuffer, 0, 0, 32);
-      memo = StellarSdk.Memo.hash(anchorMemoBuffer);
-      break;
-    case "id":
-      memo = StellarSdk.Memo.id(stellar_memo);
-      break;
-  }
-  return memo;
-};
-
 module.exports = {
   instruction:
     "Now that the anchor is expecting payment to a stellar address, we need to make that payment",
   action: "Send the stellar payment",
-  execute: async function(state, { request }) {
+  execute: async function(state, { request, expect }) {
     const USER_SK = Config.get("USER_SK");
     const HORIZON_URI = Config.get("HORIZON_URI");
     const pk = StellarSdk.Keypair.fromSecret(USER_SK).publicKey();
@@ -40,11 +20,16 @@ module.exports = {
 
     let memo;
     try {
-      memo = generateMemo(state.stellar_memo, state.stellar_memo_type);
+      const memoType = {
+        text: StellarSdk.Memo.text,
+        id: StellarSdk.Memo.id,
+        hash: StellarSdk.Memo.hash
+      }[state.stellar_memo_type];
+      memo = memoType(state.stellar_memo);
     } catch (e) {
       expect(
         false,
-        `The memo '${state.stellar_memo} could not be encoded to type ${
+        `The memo '${state.stellar_memo}' could not be encoded to type ${
           state.stellar_memo_type
         }`
       );

--- a/src/util/get.js
+++ b/src/util/get.js
@@ -4,7 +4,7 @@ module.exports = async function(path, params = {}, options = {}) {
   const url = new URL(path, window.location);
   Object.keys(params).forEach(key => url.searchParams.append(key, params[key]));
   const result = await fetch(url, options);
-  if (result.headers.get("content-type").indexOf("application/json") == 0) {
+  if (result.headers.get("content-type").indexOf("json") != 0) {
     return result.json();
   }
   // Error case


### PR DESCRIPTION
Instead of allowing the server to return any string which we then coerce into a base64 buffer, we expect servers to send back the actual hex (or whatever memo type) that should actually be in the buffer.  This removes some special cases and should work for everyone now.
Fixes #26 
Also fixes #31 by using p70 fee stats to set the fee