### PR TITLE
Set proper initial button state

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,9 @@ const depositSteps = [
 
 let steps = null;
 
+uiActions.setLoading(true, "Waiting for user...");
 uiActions.waitForPageMessage("pages/wallet.html").then((message) => {
+  uiActions.setLoading(false);
   if (message === "start-withdraw") {
     steps = withdrawSteps;
     next();


### PR DESCRIPTION
Now that we are waiting to see which flow to take off, the continue button was appearing as active when it shouldnt.  Show as waiting until we actually are ready