### PR TITLE
Style the wallet receipt page

### DIFF
--- a/pages/receipt.html
+++ b/pages/receipt.html
@@ -5,12 +5,25 @@
     <style></style>
   </head>
   <body>
-    <h1>Stellar Wallet</h1>
-    <h2>Success!</h2>
-    <h3>
-      Payment confirmed with external reference number
-      <span data-replace="reference_number"></span>
-    </h3>
+    <div class="container">
+      <div class="success">
+        <img class="success__icon" src="../src/assets/success.svg" />
+        <h1 class="success__title">Success!</h1>
+      </div>
+
+      <div class="card">
+        <div class="reference">
+          <p class="reference-text">
+            Payment confirmed with external reference number:
+          </p>
+          <p data-replace="reference_number" class="reference-number"></p>
+        </div>
+      </div>
+
+      <div class="receipt-buttons">
+        <div class="button">Close</div>
+      </div>
+    </div>
   </body>
   <script src="/wallet.js"></script>
 </html>

--- a/src/assets/success.svg
+++ b/src/assets/success.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="86px" height="86px" viewBox="0 0 86 86" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 56.3 (81716) - https://sketch.com -->
+    <title>Icon check large</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Wallet-receipt" transform="translate(-106.000000, -93.000000)">
+            <g id="Icon-check-large" transform="translate(106.000000, 93.000000)">
+                <g id="Group-4">
+                    <circle id="Oval" stroke="#00AA46" stroke-width="7" cx="43" cy="43" r="39.5"></circle>
+                    <g id="noun_Check_2493114" transform="translate(25.000000, 29.000000)" fill="#00AA46">
+                        <polygon id="Path" points="37 5.25 12.4894515 28 0 12.25 5.15189873 7.47727273 12.8016878 18.1363636 32.3164557 0"></polygon>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/styles/_form.scss
+++ b/src/styles/_form.scss
@@ -20,7 +20,7 @@ label {
 }
 
 input[type="text"] {
-  font-family: suisse-mono, suisse, sans-serif;
+  font-family: $mono-typeface;
   font-size: 0.875rem;
   letter-spacing: -0.05rem;
   color: $black-70;

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -11,7 +11,7 @@ html {
 *:before,
 *:after {
   box-sizing: inherit;
-  font-family: suisse, sans-serif;
+  font-family: $main-typeface;
 }
 
 .layout-wrapper {

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -5,13 +5,13 @@ html {
   height: 100%;
   background: $black-5;
   box-sizing: border-box;
+  font-family: $main-typeface;
 }
 
 *,
 *:before,
 *:after {
   box-sizing: inherit;
-  font-family: $main-typeface;
 }
 
 .layout-wrapper {

--- a/src/styles/_logs.scss
+++ b/src/styles/_logs.scss
@@ -76,6 +76,7 @@
 }
 
 .renderjson {
+  font-family: $mono-typeface;
   margin: 0;
   overflow: scroll;
   scrollbar-width: none;

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,3 +1,8 @@
+/* Typography */
+
+$main-typeface: suisse, sans-serif;
+$mono-typeface: suisse-mono, suisse, sans-serif;
+
 /* Colors */
 
 $green: #00aa46;

--- a/src/wallet.scss
+++ b/src/wallet.scss
@@ -43,7 +43,7 @@
 
 html,
 body {
-  font-family: suisse, sans-serif;
+  font-family: $main-typeface;
   background: white;
   height: 100%;
   margin: 0;
@@ -180,6 +180,7 @@ h2 {
   border: none;
   box-sizing: border-box;
   display: block;
+  text-align: center;
   font-weight: 500;
   text-transform: uppercase;
   font-size: 1.0625rem;
@@ -261,7 +262,7 @@ h2 {
 }
 
 .sending-key {
-  font-family: suisse-mono, monospace;
+  font-family: $mono-typeface;
   margin-bottom: 8px;
 }
 
@@ -279,4 +280,44 @@ h2 {
   .active {
     margin-bottom: 25px;
   }
+}
+
+/* Receipt page */
+
+.success {
+  text-align: center;
+  margin: 90px 0 40px 0;
+}
+
+.success__icon {
+  margin-bottom: 10px;
+}
+
+.success__title {
+  font-size: 28/16 + rem;
+  color: $black-100;
+  font-weight: 500;
+}
+
+.reference {
+  text-align: center;
+  padding: 10px 0;
+}
+
+.reference-text {
+  font-size: 14/16 + rem;
+  font-weight: 500;
+  color: $black-70;
+  padding-bottom: 12px;
+}
+
+.reference-number {
+  color: $black-100;
+  display: block;
+  font-family: $mono-typeface;
+  font-size: 24/16 + rem;
+}
+
+.receipt-buttons {
+  margin-top: 45px;
 }


### PR DESCRIPTION
Style the wallet receipt page ( issue #49 ).
Change code blocks font to monospaced.