### PR TITLE
Pass jwt to withdraw/transaction/deposit endpoints

### DIFF
--- a/src/steps/deposit/get_deposit.js
+++ b/src/steps/deposit/get_deposit.js
@@ -16,28 +16,30 @@ module.exports = {
     state.deposit_memo = crypto.randomBytes(64).toString("base64");
     state.deposit_memo_type;
     instruction(
-      `We've created the deposit memo ${
-        state.deposit_memo
-      } to listen for a successful deposit`
+      `We've created the deposit memo ${state.deposit_memo} to listen for a successful deposit`,
     );
     const params = {
       asset_code: ASSET_CODE,
       account: pk,
       memo: state.deposit_memo,
-      memo_type: state.deposit_memo_type
+      memo_type: state.deposit_memo_type,
     };
     request("GET /deposit", params);
     // Expect this to fail with 403
-    const result = await get(`${BRIDGE_URL}/deposit`, params);
+    const result = await get(`${BRIDGE_URL}/deposit`, params, {
+      headers: {
+        Authorization: `Bearer ${state.token}`,
+      },
+    });
     response("GET /deposit", result);
     expect(
       result.type === "interactive_customer_info_needed",
-      `Expected interactive customer needed, received ${result.type}`
+      `Expected interactive customer needed, received ${result.type}`,
     );
     instruction(
       "GET /deposit tells us we need to collect info interactively.  The URL for the interactive portion is " +
-        result.url
+        result.url,
     );
     state.interactive_url = result.url;
-  }
+  },
 };

--- a/src/steps/get_withdraw.js
+++ b/src/steps/get_withdraw.js
@@ -16,11 +16,14 @@ module.exports = {
       type: withdrawType,
       asset_code: ASSET_CODE,
       account: pk,
-      jwt: state.token,
     };
     request("GET /withdraw", params);
     // Expect this to fail with 403
-    const result = await get(`${BRIDGE_URL}/withdraw`, params);
+    const result = await get(`${BRIDGE_URL}/withdraw`, params, {
+      headers: {
+        Authorization: `Bearer ${state.token}`,
+      },
+    });
     response("GET /withdraw", result);
     instruction(
       "GET /withdraw tells us we need to collect info interactively.  The URL for the interactive portion is " +

--- a/src/steps/poll_for_success.js
+++ b/src/steps/poll_for_success.js
@@ -19,6 +19,11 @@ module.exports = {
         const transactionResult = await get(
           `${BRIDGE_URL}/transaction`,
           transactionParams,
+          {
+            headers: {
+              Authorization: `Bearer ${state.token}`,
+            },
+          },
         );
         response("GET /transaction", transactionResult);
         if (transactionResult.transaction.status === "completed") {


### PR DESCRIPTION
We were not passing any token to the /transaction or /deposit endpoint, and in withdraw we were sending it as a query param which is technically allowed but should not be.  Move to using the proper header approach