### PR TITLE
Stop using success

### DIFF
--- a/src/steps/withdraw/show_interactive_webapp.js
+++ b/src/steps/withdraw/show_interactive_webapp.js
@@ -38,23 +38,23 @@ module.exports = {
               transaction.status === "pending_user_transfer_start",
               "Unknown transaction status: " + transaction.status,
             );
-            response("postMessage: Interactive webapp completed", e.data);
+            response("postMessage: Interactive webapp completed", transaction);
             expect(
-              e.data.withdraw_anchor_account,
+              transaction.withdraw_anchor_account,
               "withdraw_anchor_account undefined in postMessage success",
             );
             expect(
-              e.data.withdraw_memo,
+              transaction.withdraw_memo,
               "withdraw_memo undefined in postMessage success",
             );
             expect(
-              e.data.withdraw_memo_type,
+              transaction.withdraw_memo_type,
               "withdraw_memo_type undefined in postMessage success",
             );
-            state.anchors_stellar_address = e.data.withdraw_anchor_account;
-            state.stellar_memo = e.data.withdraw_memo;
-            state.stellar_memo_type = e.data.withdraw_memo_type;
-            state.withdraw_amount = e.data.amount_in;
+            state.anchors_stellar_address = transaction.withdraw_anchor_account;
+            state.stellar_memo = transaction.withdraw_memo;
+            state.stellar_memo_type = transaction.withdraw_memo_type;
+            state.withdraw_amount = transaction.amount_in;
             resolve();
           }
           if (e.data.type === "log") {

--- a/src/steps/withdraw/show_interactive_webapp.js
+++ b/src/steps/withdraw/show_interactive_webapp.js
@@ -21,17 +21,8 @@ module.exports = {
       window.addEventListener(
         "message",
         function(e) {
-          if (e.data.type === "log") {
-            instruction(e.data.message);
-          }
-          if (e.data.type === "log-object") {
-            response("postMessage", JSON.parse(e.data.obj));
-          }
-          if (e.data.type === "instruction") {
-            instruction(e.data.message);
-          }
-          if (e.data.type === "success") {
-            response("postMessage success", e.data);
+          if (e.data.status === "pending_user_transfer_start") {
+            response("postMessage: Interactive webapp completed", e.data);
             expect(
               e.data.withdraw_anchor_account,
               "withdraw_anchor_account undefined in postMessage success",
@@ -48,6 +39,15 @@ module.exports = {
             state.stellar_memo = e.data.withdraw_memo;
             state.stellar_memo_type = e.data.withdraw_memo_type;
             resolve();
+          }
+          if (e.data.type === "log") {
+            instruction(e.data.message);
+          }
+          if (e.data.type === "log-object") {
+            response("postMessage", JSON.parse(e.data.obj));
+          }
+          if (e.data.type === "instruction") {
+            instruction(e.data.message);
           }
         },
         false,

--- a/src/steps/withdraw/show_interactive_webapp.js
+++ b/src/steps/withdraw/show_interactive_webapp.js
@@ -21,7 +21,23 @@ module.exports = {
       window.addEventListener(
         "message",
         function(e) {
-          if (e.data.status === "pending_user_transfer_start") {
+          let transaction = e.data.transaction;
+          // Support older clients for now
+          if (
+            e.data.type === "success" ||
+            e.data.status === "pending_user_transfer_start"
+          ) {
+            expect(
+              false,
+              "postMessage response should have the transaction in a transaction property, not top level.  Use the @stellar/anchor-transfer-utils helper to make this easier.",
+            );
+            transaction = e.data;
+          }
+          if (transaction) {
+            expect(
+              transaction.status === "pending_user_transfer_start",
+              "Unknown transaction status: " + transaction.status,
+            );
             response("postMessage: Interactive webapp completed", e.data);
             expect(
               e.data.withdraw_anchor_account,


### PR DESCRIPTION
type: success was a vestigal way of triggering the flow.  The proper way is to check for a transaction.status == "pending_user_transfer_start".
This also fixes it so that the format is correct, matching the SEP6 `GET /transaction` endpoint which has the transaction data nested in a transaction property.
It keeps compatibility with the old format so we don't trip up the anchors currently working on it but does show an exception so they know to update.