### PR TITLE
Fix unknown network error on trustline

### DIFF
--- a/src/steps/deposit/add_trustline.js
+++ b/src/steps/deposit/add_trustline.js
@@ -22,6 +22,7 @@ module.exports = {
     console.log(asset);
     const transaction = new StellarSdk.TransactionBuilder(account, {
       fee: feeStats.p70_accepted_fee,
+      networkPassphrase: state.network,
     })
       .addOperation(
         StellarSdk.Operation.changeTrust({


### PR DESCRIPTION
Since we removed the default network, deposit flow broke and we need to specify the network used to add the trustline.