### PR TITLE
Fix broken external_transaction_id

### DIFF
--- a/src/steps/withdraw/poll_for_success.js
+++ b/src/steps/withdraw/poll_for_success.js
@@ -28,7 +28,7 @@ module.exports = {
         response("GET /transaction", transactionResult);
         if (transactionResult.transaction.status === "completed") {
           state.external_transaction_id =
-            transactionResult.transaction.externalTransactionId;
+            transactionResult.transaction.external_transaction_id;
           instruction(
             "Success!  You can pick up your cash at a storefront with reference number " +
               state.external_transaction_id,


### PR DESCRIPTION
Bad casing, easy to miss because it only shows up in one of the many instructions