### PR TITLE
Add ability to skip authentication when its not required

### DIFF
--- a/src/steps/SEP10/send.js
+++ b/src/steps/SEP10/send.js
@@ -3,6 +3,7 @@ module.exports = {
   instruction:
     "We need to send the signed SEP10 challenge back to the server to get a JWT token to authenticate our stellar account with future actions",
   action: "Send signed response back to server",
+  shouldSkip: (state) => !state.authentication_required,
   execute: async function(state, { request, response, expect }) {
     const AUTH_URL = state.auth_endpoint;
     const transaction = state.signed_challenge_tx;

--- a/src/steps/SEP10/sign.js
+++ b/src/steps/SEP10/sign.js
@@ -5,6 +5,7 @@ module.exports = {
   instruction:
     "We've received a challenge transaction from the server that we need the client to sign with our Stellar account.",
   action: "Sign Challenge (SEP-0010)",
+  shouldSkip: (state) => !state.authentication_required,
   execute: async function(state, { logObject }) {
     const USER_SK = Config.get("USER_SK");
     const challenge_xdr = state.challenge_transaction;

--- a/src/steps/SEP10/start.js
+++ b/src/steps/SEP10/start.js
@@ -6,6 +6,7 @@ module.exports = {
   instruction:
     "Start the SEP-0010 flow to authenticate the wallet's Stellar account",
   action: "GET /auth (SEP-0010)",
+  shouldSkip: (state) => !state.authentication_required,
   execute: async function(state, { request, response, instruction, expect }) {
     const USER_SK = Config.get("USER_SK");
     const AUTH_URL = state.auth_endpoint;

--- a/src/steps/deposit/check_info.js
+++ b/src/steps/deposit/check_info.js
@@ -14,9 +14,19 @@ module.exports = {
       prop(result, ["deposit", Config.get("ASSET_CODE"), "enabled"]),
       `${Config.get("ASSET_CODE")} is not enabled for deposit`,
     );
-    instruction(
-      "Deposit is enabled, and requires authentication so we should go through SEP-0010",
-    );
+    state.authentication_required = prop(result, [
+      "deposit",
+      Config.get("ASSET_CODE"),
+      "authentication_required",
+    ]);
+    if (state.authentication_required) {
+      instruction(
+        "Deposit is enabled, and requires authentication so we should go through SEP-0010",
+      );
+    } else {
+      instruction("Deposit is enabled with no authentication required");
+    }
+
     state.interactive_url = transfer_server + result.url;
   },
 };

--- a/src/steps/withdraw/check_info.js
+++ b/src/steps/withdraw/check_info.js
@@ -1,5 +1,5 @@
-const Config = require("../config");
-const get = require("../util/get");
+const Config = require("src/config");
+const get = require("src/util/get");
 const prop = require("lodash.get");
 
 module.exports = {
@@ -14,9 +14,19 @@ module.exports = {
       prop(result, ["withdraw", Config.get("ASSET_CODE"), "enabled"]),
       `${Config.get("ASSET_CODE")} is not enabled for withdraw`,
     );
-    instruction(
-      "Withdraw is enabled, and requires authentication so we should go through SEP-0010",
-    );
+    state.authentication_required = prop(result, [
+      "deposit",
+      Config.get("ASSET_CODE"),
+      "authentication_required",
+    ]);
+    if (state.authentication_required) {
+      instruction(
+        "Withdraw is enabled, and requires authentication so we should go through SEP-0010",
+      );
+    } else {
+      instruction("Withdraw is enabled with no authentication required");
+    }
+
     state.interactive_url = transfer_server + result.url;
   },
 };


### PR DESCRIPTION
Some anchors don't need authentication so we should check for it in the /info request and skip the SEP10 steps if needed
add ability for a shouldSkip lambda that allows steps to dynamically choose to run or not.