### PR TITLE
Allow trailing slashes for URLs in config

### DIFF
--- a/src/steps/check_toml.js
+++ b/src/steps/check_toml.js
@@ -23,6 +23,7 @@ module.exports = {
       if (HOME_DOMAIN.indexOf("http") != 0) {
         HOME_DOMAIN = "https://" + HOME_DOMAIN;
       }
+      HOME_DOMAIN = HOME_DOMAIN.replace(/\/$/, "");
       request(`${HOME_DOMAIN}/.well-known/stellar.toml`);
       const resp = await fetch(`${HOME_DOMAIN}/.well-known/stellar.toml`);
       const text = await resp.text();
@@ -88,5 +89,11 @@ module.exports = {
     } else {
       instruction("Received asset issuer from TOML: " + state.asset_issuer);
     }
+    if (state.transfer_server)
+      state.transfer_server = state.transfer_server.replace(/\/$/, "");
+    if (state.auth_endpoint)
+      state.transfer_server = state.transfer_server.replace(/\/$/, "");
+    if (state.transfer_server)
+      state.transfer_server = state.transfer_server.replace(/\/$/, "");
   },
 };

--- a/src/steps/check_toml.js
+++ b/src/steps/check_toml.js
@@ -92,8 +92,6 @@ module.exports = {
     if (state.transfer_server)
       state.transfer_server = state.transfer_server.replace(/\/$/, "");
     if (state.auth_endpoint)
-      state.transfer_server = state.transfer_server.replace(/\/$/, "");
-    if (state.transfer_server)
-      state.transfer_server = state.transfer_server.replace(/\/$/, "");
+      state.auth_endpoint = state.auth_endpoint.replace(/\/$/, "");
   },
 };


### PR DESCRIPTION
Currently if you add a HOME_DOMAIN or transfer server url with a trailing slash our client chokes.  This strips them out right at the beginning so we can simply concat everywhere else.

Fixes #98 