### PR TITLE
Allow pending_user_transaction_start

### DIFF
--- a/src/steps/withdraw/poll_for_success.js
+++ b/src/steps/withdraw/poll_for_success.js
@@ -43,9 +43,12 @@ module.exports = {
           }
           resolve();
         } else if (
-          ["pending_external", "pending_anchor", "pending_stellar"].indexOf(
-            transactionResult.transaction.status,
-          ) != -1
+          [
+            "pending_external",
+            "pending_anchor",
+            "pending_stellar",
+            "pending_user_transfer_start",
+          ].indexOf(transactionResult.transaction.status) != -1
         ) {
           instruction(
             `Status is ${transactionResult.transaction.status}, lets retry in 2s`,


### PR DESCRIPTION
One of the valid statuses for a transaction is pending_user_transaction_start.  We weren't allowing this previously because other anchors would pass that status back only from the webapp postMessage, but its totally valid to have it be a response to `/transaction` since the anchor doesn't actually know when a user makes a transaction until it actually shows up on the ledger