### PR TITLE
Show proper errors when there's no currency in the toml

### DIFF
--- a/src/steps/check_toml.js
+++ b/src/steps/check_toml.js
@@ -45,7 +45,7 @@ module.exports = {
           "Toml file doesn't contain a currency entry for " + ASSET_CODE,
         );
         expect(
-          asset.issuer && asset.issuer.length == 56,
+          asset && asset.issuer && asset.issuer.length == 56,
           "Toml file asset doesn't contain a valid 56 character issuer",
         );
 


### PR DESCRIPTION
If there's no matching asset from your config and the toml, we used to throw an exception which would just be reported as `invalid toml`.  That's not really true, the actual problem was just that the toml didn't have the right entry, and so we make sure  to show that and only that error.