### PR TITLE
Update the wording for the end of the deposit flow

### DIFF
--- a/src/steps/deposit/show_deposit_info.js
+++ b/src/steps/deposit/show_deposit_info.js
@@ -14,9 +14,7 @@ module.exports = {
       const urlBuilder = new URL(state.deposit_url);
       urlBuilder.searchParams.set("jwt", state.token);
       const url = urlBuilder.toString();
-      action(
-        `Launching interactive webapp at ${url} and watching for postMessage callback`,
-      );
+      action(`Showing the receipt for deposit at ${url}`);
       setDevicePage(url);
     });
   },


### PR DESCRIPTION
The action instructions for showing the `more info url` receipt was wrong due to copypasta