### PR TITLE
Cleanly finish flow

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ uiActions.waitForPageMessage("pages/wallet.html").then((message) => {
 let currentStep = null;
 const runStep = (step) => {
   if (!step) {
-    uiActions.setLoading(true, "Finished");
+    uiActions.finish();
     return;
   }
   uiActions.setDevicePage(step.devicePage || "pages/loader.html");
@@ -120,6 +120,7 @@ const runStep = (step) => {
 };
 
 const nextActiveStep = () => {
+  if (steps.length == 0) return null;
   while (steps[0].shouldSkip && steps[0].shouldSkip(state)) {
     steps.splice(0, 1);
   }
@@ -141,8 +142,9 @@ const next = async () => {
       uiActions.setLoading(false);
       throw e;
     }
-
-    uiActions.setLoading(false, nextActiveStep().action);
+    const nextStep = nextActiveStep();
+    const nextAction = nextStep && nextStep.action;
+    uiActions.setLoading(false, nextAction);
   }
   runStep(nextActiveStep());
 };

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -29,6 +29,12 @@
       animation: rotate 2s linear infinite;
     }
   }
+
+  &.finished {
+    background: $muted-purple;
+    animation: none;
+    padding-left: 48px;
+  }
 }
 
 @keyframes rotate {

--- a/src/ui/ui-actions.js
+++ b/src/ui/ui-actions.js
@@ -68,6 +68,13 @@ const setLoading = (loading, loadingMessage) => {
   }
 };
 
+const finish = () => {
+  actionButton.textContent = "Finished!";
+  actionButton.disabled = true;
+  actionButton.classList.remove("loading");
+  actionButton.classList.add("finished");
+};
+
 /*
  * Assertions to ensure things are going correctly,
  * and to bail early if not.  Currently just shows
@@ -113,6 +120,7 @@ module.exports = {
 
   onNext,
   setLoading,
+  finish,
 
   showConfig,
   setDevicePage,


### PR DESCRIPTION
Currently when we finish the flow the button ends with 'waiting' even though there's nothing to do.  There's also a JS exception that doesn't really have an impact.  This will create a .finish() uiAction that actually changes the button to a finished state, and cleanly ends the flow.