### PR TITLE
Don't send cash type

### DIFF
--- a/src/steps/withdraw/get_withdraw.js
+++ b/src/steps/withdraw/get_withdraw.js
@@ -11,9 +11,7 @@ module.exports = {
     const USER_SK = Config.get("USER_SK");
     const pk = StellarSDK.Keypair.fromSecret(USER_SK).publicKey();
     const transfer_server = state.transfer_server;
-    const withdrawType = "cash";
     const params = {
-      type: withdrawType,
       asset_code: ASSET_CODE,
       account: pk,
     };


### PR DESCRIPTION
the type field is optional for interactive flows, so we should ensure that no anchors require it.  Don't merge until partners have a chance to update.