### PR TITLE
Fix janky loader

### DIFF
--- a/pages/loader.html
+++ b/pages/loader.html
@@ -9,6 +9,7 @@
         align-content: center;
         align-items: center;
         height: 100%;
+        overflow: hidden;
       }
       .loader {
         border: 10px solid #debeff;


### PR DESCRIPTION
The rotating loader screen was causing some weird page reiszing to show the spinners.  This just makes overflow hidden so it doesn't try to resize itself.