### PR TITLE
Properly poll for the transaction id not the memo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,9 @@ const StellarSdk = require("stellar-sdk");
  * @property {Object} signed_challenge_tx - Stellar transaction challenge signed by both server and client
  * @property {string} token - JWT token representing authentication with stellar address from SEP10
  *
+ * Deposit/withdraw
+ * @property {string} transaction_id - Anchor identifier for transaction
+ *
  * Withdraw
  * @property {string} anchors_stellar_address - Address that the anchor will be expecting payment on for the in-flight transaction
  * @property {string} stellar_memo_type - Memo type for the stellar transaction to specify the anchor's transaction

--- a/src/steps/withdraw/poll_for_success.js
+++ b/src/steps/withdraw/poll_for_success.js
@@ -13,7 +13,7 @@ module.exports = {
       const transfer_server = state.transfer_server;
       const poll = async () => {
         const transactionParams = {
-          id: state.stellar_memo,
+          id: state.transaction_id,
         };
         request("GET /transaction", transactionParams);
         const transactionResult = await get(

--- a/src/steps/withdraw/send_stellar_transaction.js
+++ b/src/steps/withdraw/send_stellar_transaction.js
@@ -67,10 +67,11 @@ module.exports = {
       const data = e.response.data;
       const status = data.status;
       const txStatus = data.extras.result_codes.transaction;
-      const codes = data.extras.result_codes.operations.join(", ");
+      const codes = data.extras.result_codes.operations;
+      const codesList = codes ? codes.join(", ") : "";
       expect(
         false,
-        `Sending transaction failed with error code ${status}: ${txStatus}, ${codes}`,
+        `Sending transaction failed with error code ${status}: ${txStatus}, ${codesList}`,
       );
     }
   },

--- a/src/steps/withdraw/show_interactive_webapp.js
+++ b/src/steps/withdraw/show_interactive_webapp.js
@@ -55,6 +55,7 @@ module.exports = {
             state.stellar_memo = transaction.withdraw_memo;
             state.stellar_memo_type = transaction.withdraw_memo_type;
             state.withdraw_amount = transaction.amount_in;
+            state.transaction_id = transaction.id;
             resolve();
           }
           if (e.data.type === "log") {

--- a/src/steps/withdraw/show_interactive_webapp.js
+++ b/src/steps/withdraw/show_interactive_webapp.js
@@ -41,21 +41,25 @@ module.exports = {
             response("postMessage: Interactive webapp completed", transaction);
             expect(
               transaction.withdraw_anchor_account,
-              "withdraw_anchor_account undefined in postMessage success",
+              "withdraw_anchor_account undefined in postMessage callback",
             );
             expect(
               transaction.withdraw_memo,
-              "withdraw_memo undefined in postMessage success",
+              "withdraw_memo undefined in postMessage callback",
             );
             expect(
               transaction.withdraw_memo_type,
-              "withdraw_memo_type undefined in postMessage success",
+              "withdraw_memo_type undefined in postMessage callback.",
+            );
+            expect(
+              transaction.id,
+              "id is undefined in postMessage callback.  Falling back to using memo as ID, but this will be removed shortly.  Please send an explicit id field.",
             );
             state.anchors_stellar_address = transaction.withdraw_anchor_account;
             state.stellar_memo = transaction.withdraw_memo;
             state.stellar_memo_type = transaction.withdraw_memo_type;
             state.withdraw_amount = transaction.amount_in;
-            state.transaction_id = transaction.id;
+            state.transaction_id = transaction.id || state.stellar_memo;
             resolve();
           }
           if (e.data.type === "log") {


### PR DESCRIPTION
We were originally using the memo as the transaction ID, but thats not necessarily true for every anchor.