### PR TITLE
Assertfinalstep

### DIFF
--- a/src/steps/deposit/show_interactive_webapp.js
+++ b/src/steps/deposit/show_interactive_webapp.js
@@ -33,13 +33,14 @@ module.exports = {
           if (transaction) {
             expect(
               transaction.status === "completed" ||
-                transaction.status === "pending_external",
+                transaction.status === "pending_external" ||
+                transaction.status === "pending_user_transfer_start",
               "Unknown transaction status: " + transaction.status,
             );
             response("postMessage: Interactive webapp completed", transaction);
             expect(
-              transaction.more_info_url || transaction.external_transaction_id,
-              "postMessage callback must contain a more_info_url or external_transaction_id",
+              transaction.more_info_url,
+              "postMessage callback must contain a more_info_url with information on how to finish the deposit",
             );
             state.deposit_url = transaction.more_info_url;
             resolve();

--- a/src/steps/withdraw/poll_for_success.js
+++ b/src/steps/withdraw/poll_for_success.js
@@ -7,7 +7,7 @@ module.exports = {
   action: "GET /transaction (SEP6)",
   execute: async function(
     state,
-    { request, response, instruction, error, setDevicePage },
+    { request, response, instruction, error, expect, setDevicePage },
   ) {
     return new Promise((resolve, reject) => {
       const transfer_server = state.transfer_server;
@@ -27,6 +27,11 @@ module.exports = {
         );
         response("GET /transaction", transactionResult);
         if (transactionResult.transaction.status === "completed") {
+          expect(
+            transactionResult.transaction.external_transaction_id ||
+              transactionResult.transaction.more_info_url,
+            "Provide a more_info_url or external_transaction_id to show proper results",
+          );
           state.external_transaction_id =
             transactionResult.transaction.external_transaction_id;
           instruction(


### PR DESCRIPTION
require more_info_url for deposit.  There's no way to go forward with just external_transaction_id.   We shouldn't allow it in withdraw either but one thing at a time.