### PR TITLE
Start polling deposit for finish state

### DIFF
--- a/src/steps/deposit/show_close_button.js
+++ b/src/steps/deposit/show_close_button.js
@@ -1,21 +1,61 @@
+const get = require("src/util/get");
+
 module.exports = {
   instruction:
     "Let the user close the webapp to see the accounts list, and jump back to the deposit url",
   autoStart: true,
   execute: async function(
     state,
-    { setDevicePage, showClosePanel, waitForPageMessage },
+    { request, response, expect, instruction, setDevicePage, showClosePanel },
   ) {
-    return new Promise((resolve, reject) => {
-      const showClose = async () => {
-        showClosePanel(true, () => {
-          setDevicePage("pages/transactions.html?pending=true");
-          showClosePanel(false);
-        });
-        await waitForPageMessage(state.deposit_url);
-        showClose();
+    let lastStatus = "pending_user_transfer_start";
+    let showingDepositView = true;
+    const poll = async () => {
+      const transfer_server = state.transfer_server;
+      const transactionParams = {
+        id: state.transaction_id,
       };
-      showClose();
+      request("GET /transaction", transactionParams);
+      const transactionResult = await get(
+        `${transfer_server}/transaction`,
+        transactionParams,
+        {
+          headers: {
+            Authorization: `Bearer ${state.token}`,
+          },
+        },
+      );
+      response("GET /transaction", transactionResult);
+      if (
+        transactionResult.transaction.status === "pending_user_transfer_start"
+      ) {
+        instruction("Still pending user transfer, try again in 5s");
+        setTimeout(poll, 5000);
+      } else if (transactionResult.transaction.status !== lastStatus) {
+        console.log(
+          "Setting last status to ",
+          transactionResult.transaction.status,
+        );
+        lastStatus = transactionResult.transaction.status;
+        state.deposit_url = transactionResult.transaction.more_info_url;
+        if (showingDepositView) setDevicePage(state.deposit_url);
+      }
+    };
+    return new Promise((resolve, reject) => {
+      poll();
+
+      showClosePanel(true);
+      setDevicePage(state.deposit_url);
+      const cb = function(e) {
+        if (e.data.message === "show-transaction") {
+          setDevicePage(state.deposit_url);
+          showingDepositView = true;
+        } else if (e.data.message === "close-button") {
+          showingDepositView = false;
+          setDevicePage("pages/transactions.html?pending=true");
+        }
+      };
+      window.addEventListener("message", cb);
     });
   },
 };

--- a/src/steps/deposit/show_interactive_webapp.js
+++ b/src/steps/deposit/show_interactive_webapp.js
@@ -44,7 +44,12 @@ module.exports = {
               transaction.more_info_url,
               "postMessage callback must contain a more_info_url with information on how to finish the deposit",
             );
+            expect(
+              transaction.id,
+              "postMessage callback transaction contains no id",
+            );
             state.deposit_url = transaction.more_info_url;
+            state.transaction_id = transaction.id;
             resolve();
           }
           if (e.data.type === "log") {

--- a/src/ui/ui-actions.js
+++ b/src/ui/ui-actions.js
@@ -86,16 +86,16 @@ const expect = (expectation, message) => {
   }
 };
 
-const showClosePanel = (show, callback) => {
-  const panel = $("close-panel");
-  panel.style.display = show ? null : "none";
-  const cb = () => {
-    window.postMessage({
-      message: "close-button",
-    });
-    panel.style.display = "none";
-  };
-  panel.addEventListener("click", cb);
+const panel = $("close-panel");
+const cb = () => {
+  window.postMessage({
+    message: "close-button",
+  });
+  panel.style.display = "none";
+};
+panel.addEventListener("click", cb);
+const showClosePanel = () => {
+  panel.style.display = null;
 };
 
 const setDevicePage = (src) => {

--- a/src/ui/ui-actions.js
+++ b/src/ui/ui-actions.js
@@ -90,8 +90,10 @@ const showClosePanel = (show, callback) => {
   const panel = $("close-panel");
   panel.style.display = show ? null : "none";
   const cb = () => {
-    panel.removeEventListener("click", cb);
-    if (callback) callback();
+    window.postMessage({
+      message: "close-button",
+    });
+    panel.style.display = "none";
   };
   panel.addEventListener("click", cb);
 };


### PR DESCRIPTION
Instead of needing to go back and forth to transactions view to see the more_info page update, we can poll the /transaction endpoint to see if the state changed.