### PR TITLE
Warn when apis or interactive urls are http

### DIFF
--- a/src/steps/check_toml.js
+++ b/src/steps/check_toml.js
@@ -93,5 +93,13 @@ module.exports = {
       state.transfer_server = state.transfer_server.replace(/\/$/, "");
     if (state.auth_endpoint)
       state.auth_endpoint = state.auth_endpoint.replace(/\/$/, "");
+    expect(
+      state.transfer_server && state.transfer_server.indexOf("https://") === 0,
+      "Transfer server must be https",
+    );
+    expect(
+      state.auth_endpoint && state.auth_endpoint.indexOf("https://") === 0,
+      "WEB_AUTH_ENDPOINT must be https",
+    );
   },
 };

--- a/src/steps/deposit/get_deposit.js
+++ b/src/steps/deposit/get_deposit.js
@@ -40,6 +40,11 @@ module.exports = {
       "GET /deposit tells us we need to collect info interactively.  The URL for the interactive portion is " +
         result.url,
     );
+    expect(result.url, "An interactive webapp URL is required");
+    expect(
+      result.url && result.url.indexOf("https://") === 0,
+      "Interactive URLs (and all endpoints) must be served over https",
+    );
     state.interactive_url = result.url;
   },
 };

--- a/src/steps/withdraw/get_withdraw.js
+++ b/src/steps/withdraw/get_withdraw.js
@@ -28,6 +28,10 @@ module.exports = {
       "The only supported type is interactive_customer_info_needed",
     );
     expect(result.url, "An interactive webapp URL is required");
+    expect(
+      result.url && result.url.indexOf("https://") === 0,
+      "Interactive URLs (and all endpoints) must be served over https",
+    );
     instruction(
       "GET /withdraw tells us we need to collect info interactively.  The URL for the interactive portion is " +
         result.url,


### PR DESCRIPTION
Lots of anchors get tripped up by using http urls which cause odd browser issues from https urls.  Its also invalid for anyone in SEP6 (or anywhere involving money) to be using http.  This doesn't stop them from doing it, but will show errors whenever it happens so its clear its wrong.