### PR TITLE
Unsubscribe from postmessage when interactive flow is finished

### DIFF
--- a/src/steps/withdraw/show_interactive_webapp.js
+++ b/src/steps/withdraw/show_interactive_webapp.js
@@ -18,62 +18,60 @@ module.exports = {
         `Launching interactive webapp at ${url} and watching for postMessage callback`,
       );
       setDevicePage(url);
-      window.addEventListener(
-        "message",
-        function(e) {
-          let transaction = e.data.transaction;
-          // Support older clients for now
-          if (
-            e.data.type === "success" ||
-            e.data.status === "pending_user_transfer_start"
-          ) {
-            expect(
-              false,
-              "postMessage response should have the transaction in a transaction property, not top level.  Use the @stellar/anchor-transfer-utils helper to make this easier.",
-            );
-            transaction = e.data;
-          }
-          if (transaction) {
-            expect(
-              transaction.status === "pending_user_transfer_start",
-              "Unknown transaction status: " + transaction.status,
-            );
-            response("postMessage: Interactive webapp completed", transaction);
-            expect(
-              transaction.withdraw_anchor_account,
-              "withdraw_anchor_account undefined in postMessage callback",
-            );
-            expect(
-              transaction.withdraw_memo,
-              "withdraw_memo undefined in postMessage callback",
-            );
-            expect(
-              transaction.withdraw_memo_type,
-              "withdraw_memo_type undefined in postMessage callback.",
-            );
-            expect(
-              transaction.id,
-              "id is undefined in postMessage callback.  Falling back to using memo as ID, but this will be removed shortly.  Please send an explicit id field.",
-            );
-            state.anchors_stellar_address = transaction.withdraw_anchor_account;
-            state.stellar_memo = transaction.withdraw_memo;
-            state.stellar_memo_type = transaction.withdraw_memo_type;
-            state.withdraw_amount = transaction.amount_in;
-            state.transaction_id = transaction.id || state.stellar_memo;
-            resolve();
-          }
-          if (e.data.type === "log") {
-            instruction(e.data.message);
-          }
-          if (e.data.type === "log-object") {
-            response("postMessage", JSON.parse(e.data.obj));
-          }
-          if (e.data.type === "instruction") {
-            instruction(e.data.message);
-          }
-        },
-        false,
-      );
+      const cb = function(e) {
+        let transaction = e.data.transaction;
+        // Support older clients for now
+        if (
+          e.data.type === "success" ||
+          e.data.status === "pending_user_transfer_start"
+        ) {
+          expect(
+            false,
+            "postMessage response should have the transaction in a transaction property, not top level.  Use the @stellar/anchor-transfer-utils helper to make this easier.",
+          );
+          transaction = e.data;
+        }
+        if (transaction) {
+          expect(
+            transaction.status === "pending_user_transfer_start",
+            "Unknown transaction status: " + transaction.status,
+          );
+          response("postMessage: Interactive webapp completed", transaction);
+          expect(
+            transaction.withdraw_anchor_account,
+            "withdraw_anchor_account undefined in postMessage callback",
+          );
+          expect(
+            transaction.withdraw_memo,
+            "withdraw_memo undefined in postMessage callback",
+          );
+          expect(
+            transaction.withdraw_memo_type,
+            "withdraw_memo_type undefined in postMessage callback.",
+          );
+          expect(
+            transaction.id,
+            "id is undefined in postMessage callback.  Falling back to using memo as ID, but this will be removed shortly.  Please send an explicit id field.",
+          );
+          state.anchors_stellar_address = transaction.withdraw_anchor_account;
+          state.stellar_memo = transaction.withdraw_memo;
+          state.stellar_memo_type = transaction.withdraw_memo_type;
+          state.withdraw_amount = transaction.amount_in;
+          state.transaction_id = transaction.id || state.stellar_memo;
+          window.removeEventListener("message", cb);
+          resolve();
+        }
+        if (e.data.type === "log") {
+          instruction(e.data.message);
+        }
+        if (e.data.type === "log-object") {
+          response("postMessage", JSON.parse(e.data.obj));
+        }
+        if (e.data.type === "instruction") {
+          instruction(e.data.message);
+        }
+      };
+      window.addEventListener("message", cb, false);
     });
   },
 };


### PR DESCRIPTION
Previously we had left an event handler attached to the window for listening to messages from the interactive webapp.  This was causing odd problems hearing postMessages from later steps.