### PR TITLE
Add email address to interactive url

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -28,6 +28,12 @@ let fields = [
     optional: true,
   },
   {
+    key: "EMAIL_ADDRESS",
+    label: "(OPTIONAL) Email address to pass into interactive url",
+    value: null,
+    optional: true,
+  },
+  {
     key: "AUTO_ADVANCE",
     label: "Automatically perform background operations",
     value: false,

--- a/src/steps/deposit/show_interactive_webapp.js
+++ b/src/steps/deposit/show_interactive_webapp.js
@@ -13,6 +13,10 @@ module.exports = {
       // Add the parent_url so we can use postMessage inside the webapp
       const urlBuilder = new URL(state.interactive_url);
       urlBuilder.searchParams.set("jwt", state.token);
+      const email = Config.get("EMAIL_ADDRESS");
+      if (email) {
+        urlBuilder.searchParams.set("email_address", email);
+      }
       const url = urlBuilder.toString();
       action(
         `Launching interactive webapp at ${url} and watching for postMessage callback`,

--- a/src/steps/withdraw/show_interactive_webapp.js
+++ b/src/steps/withdraw/show_interactive_webapp.js
@@ -13,6 +13,10 @@ module.exports = {
       // Add the parent_url so we can use postMessage inside the webapp
       const urlBuilder = new URL(state.interactive_url);
       urlBuilder.searchParams.set("jwt", state.token);
+      const email = Config.get("EMAIL_ADDRESS");
+      if (email) {
+        urlBuilder.searchParams.set("email_address", email);
+      }
       const url = urlBuilder.toString();
       action(
         `Launching interactive webapp at ${url} and watching for postMessage callback`,


### PR DESCRIPTION
Wallets can send SEP-9 fields to an anchor via url params on the interactive url. This adds the ability to add an email address in case an anchor wants to test what happens when an email is sent