### PR TITLE
Assert 403 on interactive endpoints

### DIFF
--- a/src/steps/deposit/get_deposit.js
+++ b/src/steps/deposit/get_deposit.js
@@ -26,11 +26,20 @@ module.exports = {
     };
     request("GET /deposit", params);
     // Expect this to fail with 403
-    const result = await get(`${transfer_server}/deposit`, params, {
+    const url = new URL(`${transfer_server}/withdraw`);
+    Object.keys(params).forEach((key) =>
+      url.searchParams.append(key, params[key]),
+    );
+    const resp = await fetch(url, {
       headers: {
         Authorization: `Bearer ${state.token}`,
       },
     });
+    expect(
+      resp.status === 403,
+      `GET /deposit should return a 403 status code when returning interactive_customer_info_needed, received ${resp.status}`,
+    );
+    const result = await resp.json();
     response("GET /deposit", result);
     expect(
       result.type === "interactive_customer_info_needed",

--- a/src/steps/withdraw/get_withdraw.js
+++ b/src/steps/withdraw/get_withdraw.js
@@ -17,11 +17,21 @@ module.exports = {
     };
     request("GET /withdraw", params);
     // Expect this to fail with 403
-    const result = await get(`${transfer_server}/withdraw`, params, {
+    const url = new URL(`${transfer_server}/withdraw`);
+    Object.keys(params).forEach((key) =>
+      url.searchParams.append(key, params[key]),
+    );
+    const resp = await fetch(url, {
       headers: {
         Authorization: `Bearer ${state.token}`,
       },
     });
+    console.log("Status", resp.status);
+    expect(
+      resp.status === 403,
+      `GET /withdraw should return a 403 status code when returning interactive_customer_info_needed, received ${resp.status}`,
+    );
+    const result = await resp.json();
     response("GET /withdraw", result);
     expect(
       result.type == "interactive_customer_info_needed",


### PR DESCRIPTION
The SEP-6/24 specs state that the response to `GET /withdraw` or `GET /deposit` in the case of an interactive transaction is that it should respond with a 403 status code and a `type: "interactive_customer_info_needed"`.  We should assert that the response is 403 and show an error if its not.