### PR TITLE
Attach jwt to more info urls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,6 @@ const StellarSdk = require("stellar-sdk");
  *
  * From /info
  * @property {string} interactive_url - URL hosting the interactive webapp step
- * @property {boolean} authentication_required - Whether SEP10 authentication is required
  *
  * SEP10
  * @property {string} challenge_transaction - XDR Representation of Stellar challenge transaction signed by server only

--- a/src/steps/SEP10/send.js
+++ b/src/steps/SEP10/send.js
@@ -22,5 +22,6 @@ module.exports = {
     response("POST /auth", json);
     expect(json.token, "No token returned from /auth");
     state.token = json.token;
+    console.log("Token is ", state.token);
   },
 };

--- a/src/steps/SEP10/send.js
+++ b/src/steps/SEP10/send.js
@@ -3,7 +3,6 @@ module.exports = {
   instruction:
     "We need to send the signed SEP10 challenge back to the server to get a JWT token to authenticate our stellar account with future actions",
   action: "Send signed response back to server",
-  shouldSkip: (state) => !state.authentication_required,
   execute: async function(state, { request, response, expect }) {
     const AUTH_URL = state.auth_endpoint;
     const transaction = state.signed_challenge_tx;

--- a/src/steps/SEP10/sign.js
+++ b/src/steps/SEP10/sign.js
@@ -5,7 +5,6 @@ module.exports = {
   instruction:
     "We've received a challenge transaction from the server that we need the client to sign with our Stellar account.",
   action: "Sign Challenge (SEP-0010)",
-  shouldSkip: (state) => !state.authentication_required,
   execute: async function(state, { logObject }) {
     const USER_SK = Config.get("USER_SK");
     const challenge_xdr = state.challenge_transaction;

--- a/src/steps/SEP10/start.js
+++ b/src/steps/SEP10/start.js
@@ -6,7 +6,6 @@ module.exports = {
   instruction:
     "Start the SEP-0010 flow to authenticate the wallet's Stellar account",
   action: "GET /auth (SEP-0010)",
-  shouldSkip: (state) => !state.authentication_required,
   execute: async function(state, { request, response, instruction, expect }) {
     const USER_SK = Config.get("USER_SK");
     const AUTH_URL = state.auth_endpoint;

--- a/src/steps/deposit/check_info.js
+++ b/src/steps/deposit/check_info.js
@@ -14,18 +14,9 @@ module.exports = {
       prop(result, ["deposit", Config.get("ASSET_CODE"), "enabled"]),
       `${Config.get("ASSET_CODE")} is not enabled for deposit`,
     );
-    state.authentication_required = prop(result, [
-      "deposit",
-      Config.get("ASSET_CODE"),
-      "authentication_required",
-    ]);
-    if (state.authentication_required) {
-      instruction(
-        "Deposit is enabled, and requires authentication so we should go through SEP-0010",
-      );
-    } else {
-      instruction("Deposit is enabled with no authentication required");
-    }
+    instruction(
+      "Deposit is enabled, and requires authentication so we should go through SEP-0010",
+    );
 
     state.interactive_url = transfer_server + result.url;
   },

--- a/src/steps/deposit/show_close_button.js
+++ b/src/steps/deposit/show_close_button.js
@@ -30,7 +30,9 @@ module.exports = {
       if (lastStatus !== transactionResult.transaction.status) {
         lastStatus = transactionResult.transaction.status;
         instruction(`Status updated to ${lastStatus}`);
-        state.deposit_url = transactionResult.transaction.more_info_url;
+        const urlBuilder = new URL(transactionResult.transaction.more_info_url);
+        urlBuilder.set("jwt", state.token);
+        state.deposit_url = urlBuilder.toString();
         if (showingDepositView) {
           showDepositView();
         }

--- a/src/steps/deposit/show_close_button.js
+++ b/src/steps/deposit/show_close_button.js
@@ -31,7 +31,7 @@ module.exports = {
         lastStatus = transactionResult.transaction.status;
         instruction(`Status updated to ${lastStatus}`);
         const urlBuilder = new URL(transactionResult.transaction.more_info_url);
-        urlBuilder.set("jwt", state.token);
+        urlBuilder.searchParams.set("jwt", state.token);
         state.deposit_url = urlBuilder.toString();
         if (showingDepositView) {
           showDepositView();

--- a/src/steps/deposit/show_deposit_info.js
+++ b/src/steps/deposit/show_deposit_info.js
@@ -11,11 +11,8 @@ module.exports = {
   ) {
     return new Promise((resolve, reject) => {
       // Add the parent_url so we can use postMessage inside the webapp
-      const urlBuilder = new URL(state.deposit_url);
-      urlBuilder.searchParams.set("jwt", state.token);
-      const url = urlBuilder.toString();
       action(`Showing the receipt for deposit at ${url}`);
-      setDevicePage(url);
+      setDevicePage(state.deposit_url);
     });
   },
 };

--- a/src/steps/deposit/show_interactive_webapp.js
+++ b/src/steps/deposit/show_interactive_webapp.js
@@ -52,7 +52,9 @@ module.exports = {
               transaction.id,
               "postMessage callback transaction contains no id",
             );
-            state.deposit_url = transaction.more_info_url;
+            const urlBuilder = new URL(transaction.more_info_url);
+            urlBuilder.searchParams.set("jwt", state.token);
+            state.deposit_url = urlBuilder.toString();
             state.transaction_id = transaction.id;
             resolve();
           }

--- a/src/steps/withdraw/check_info.js
+++ b/src/steps/withdraw/check_info.js
@@ -14,18 +14,9 @@ module.exports = {
       prop(result, ["withdraw", Config.get("ASSET_CODE"), "enabled"]),
       `${Config.get("ASSET_CODE")} is not enabled for withdraw`,
     );
-    state.authentication_required = prop(result, [
-      "deposit",
-      Config.get("ASSET_CODE"),
-      "authentication_required",
-    ]);
-    if (state.authentication_required) {
-      instruction(
-        "Withdraw is enabled, and requires authentication so we should go through SEP-0010",
-      );
-    } else {
-      instruction("Withdraw is enabled with no authentication required");
-    }
+    instruction(
+      "Withdraw is enabled, and requires authentication so we should go through SEP-0010",
+    );
 
     state.interactive_url = transfer_server + result.url;
   },

--- a/src/steps/withdraw/poll_for_success.js
+++ b/src/steps/withdraw/poll_for_success.js
@@ -39,7 +39,11 @@ module.exports = {
               state.external_transaction_id,
           );
           if (transactionResult.transaction.more_info_url) {
-            setDevicePage(transactionResult.transaction.more_info_url);
+            const urlBuilder = new URL(
+              transactionResult.transaction.more_info_url,
+            );
+            urlBuilder.searchParams.set("jwt", state.token);
+            setDevicePage(urlBuilder.toString());
           } else {
             setDevicePage(
               "pages/receipt.html?reference_number=" +


### PR DESCRIPTION
We need to authenticate for the transaction details screens so we attach jwt to the urls we get back from the server before launching them.