### PR TITLE
Don't overlap the close button on top of the content, put it underneath

### DIFF
--- a/src/styles/_device.scss
+++ b/src/styles/_device.scss
@@ -44,10 +44,10 @@ $frame-border-radius: 59px;
   width: 100%;
   height: 100%;
   position: relative;
+  display: flex;
+  flex-direction: column;
 
   #close-panel {
-    position: absolute;
-    bottom: 0;
     width: 100%;
     height: 140px;
     background: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
Instead of putting the close button over the iframe, put it under the iframe.