### PR TITLE
Don't check for https on testnet

### DIFF
--- a/src/steps/check_toml.js
+++ b/src/steps/check_toml.js
@@ -1,5 +1,4 @@
 const Config = require("src/config");
-const prop = require("lodash.get");
 const toml = require("toml");
 
 module.exports = {
@@ -93,13 +92,16 @@ module.exports = {
       state.transfer_server = state.transfer_server.replace(/\/$/, "");
     if (state.auth_endpoint)
       state.auth_endpoint = state.auth_endpoint.replace(/\/$/, "");
-    expect(
-      state.transfer_server && state.transfer_server.indexOf("https://") === 0,
-      "Transfer server must be https",
-    );
-    expect(
-      state.auth_endpoint && state.auth_endpoint.indexOf("https://") === 0,
-      "WEB_AUTH_ENDPOINT must be https",
-    );
+    if (Config.get("PUBNET")) {
+      expect(
+        state.transfer_server &&
+          state.transfer_server.indexOf("https://") === 0,
+        "Transfer server must be https",
+      );
+      expect(
+        state.auth_endpoint && state.auth_endpoint.indexOf("https://") === 0,
+        "WEB_AUTH_ENDPOINT must be https",
+      );
+    }
   },
 };

--- a/src/steps/deposit/get_deposit.js
+++ b/src/steps/deposit/get_deposit.js
@@ -41,10 +41,12 @@ module.exports = {
         result.url,
     );
     expect(result.url, "An interactive webapp URL is required");
-    expect(
-      result.url && result.url.indexOf("https://") === 0,
-      "Interactive URLs (and all endpoints) must be served over https",
-    );
+    if (Config.get("PUBNET")) {
+      expect(
+        result.url && result.url.indexOf("https://") === 0,
+        "Interactive URLs (and all endpoints) must be served over https",
+      );
+    }
     state.interactive_url = result.url;
   },
 };

--- a/src/steps/withdraw/get_withdraw.js
+++ b/src/steps/withdraw/get_withdraw.js
@@ -28,10 +28,12 @@ module.exports = {
       "The only supported type is interactive_customer_info_needed",
     );
     expect(result.url, "An interactive webapp URL is required");
-    expect(
-      result.url && result.url.indexOf("https://") === 0,
-      "Interactive URLs (and all endpoints) must be served over https",
-    );
+    if (Config.get("PUBNET")) {
+      expect(
+        result.url && result.url.indexOf("https://") === 0,
+        "Interactive URLs (and all endpoints) must be served over https",
+      );
+    }
     instruction(
       "GET /withdraw tells us we need to collect info interactively.  The URL for the interactive portion is " +
         result.url,


### PR DESCRIPTION
Most development doesn't happen on https so there's no reason to show errors unless you're testing pubnet.