### PR TITLE
Convert /deposit and /withdraw to new POST endpoints

### DIFF
--- a/src/steps/deposit/get_deposit.js
+++ b/src/steps/deposit/get_deposit.js
@@ -23,6 +23,10 @@ module.exports = {
       memo: state.deposit_memo,
       memo_type: state.deposit_memo_type,
     };
+    const email = Config.get("EMAIL_ADDRESS");
+    if (email) {
+      params.email_address = email;
+    }
     request("POST /transactions/deposit/interactive", params);
     const searchParams = new URLSearchParams();
     Object.keys(params).forEach((key) => searchParams.append(key, params[key]));

--- a/src/steps/deposit/get_deposit.js
+++ b/src/steps/deposit/get_deposit.js
@@ -1,12 +1,11 @@
 const StellarSDK = require("stellar-sdk");
 const Config = require("src/config");
-const get = require("src/util/get");
 const crypto = require("crypto");
 
 module.exports = {
   instruction:
-    "In order to find out whether we need to enter the interactive or non-interactive flow, check the /deposit endpoint",
-  action: "GET /deposit (SEP-0006)",
+    "To get the url for the interactive flow check the /transactions/deposit/interactive endpoint",
+  action: "POST /transactions/deposit/interactive (SEP-0024)",
   execute: async function(state, { request, response, instruction, expect }) {
     const ASSET_CODE = Config.get("ASSET_CODE");
     const USER_SK = Config.get("USER_SK");
@@ -24,20 +23,27 @@ module.exports = {
       memo: state.deposit_memo,
       memo_type: state.deposit_memo_type,
     };
-    request("GET /deposit", params);
-    // Expect this to fail with 403
-    const result = await get(`${transfer_server}/deposit`, params, {
-      headers: {
-        Authorization: `Bearer ${state.token}`,
+    request("POST /transactions/deposit/interactive", params);
+    const searchParams = new URLSearchParams();
+    Object.keys(params).forEach((key) => searchParams.append(key, params[key]));
+    const resp = await fetch(
+      `${transfer_server}/transactions/deposit/interactive`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${state.token}`,
+        },
+        body: searchParams,
       },
-    });
-    response("GET /deposit", result);
+    );
+    const result = await resp.json();
+    response("POST /transactions/deposit/interactive", result);
     expect(
       result.type === "interactive_customer_info_needed",
       `Expected interactive customer needed, received ${result.type}`,
     );
     instruction(
-      "GET /deposit tells us we need to collect info interactively.  The URL for the interactive portion is " +
+      "POST /deposit tells us we need to collect info interactively.  The URL for the interactive portion is " +
         result.url,
     );
     expect(result.url, "An interactive webapp URL is required");

--- a/src/steps/deposit/show_interactive_webapp.js
+++ b/src/steps/deposit/show_interactive_webapp.js
@@ -13,10 +13,6 @@ module.exports = {
       // Add the parent_url so we can use postMessage inside the webapp
       const urlBuilder = new URL(state.interactive_url);
       urlBuilder.searchParams.set("jwt", state.token);
-      const email = Config.get("EMAIL_ADDRESS");
-      if (email) {
-        urlBuilder.searchParams.set("email_address", email);
-      }
       const url = urlBuilder.toString();
       action(
         `Launching interactive webapp at ${url} and watching for postMessage callback`,

--- a/src/steps/withdraw/get_withdraw.js
+++ b/src/steps/withdraw/get_withdraw.js
@@ -15,6 +15,10 @@ module.exports = {
       asset_code: ASSET_CODE,
       account: pk,
     };
+    const email = Config.get("EMAIL_ADDRESS");
+    if (email) {
+      params.email_address = email;
+    }
     request("POST /transactions/withdraw/interactive", params);
     const searchParams = new URLSearchParams();
     Object.keys(params).forEach((key) => searchParams.append(key, params[key]));

--- a/src/steps/withdraw/get_withdraw.js
+++ b/src/steps/withdraw/get_withdraw.js
@@ -4,8 +4,8 @@ const get = require("src/util/get");
 
 module.exports = {
   instruction:
-    "In order to find out whether we need to enter the interactive or non-interactive flow, check the /withdraw endpoint",
-  action: "GET /withdraw (SEP-0006)",
+    "To get the url for the interactive flow, check the /withdraw endpoint",
+  action: "POST /transactions/withdraw/interactive (SEP-0024)",
   execute: async function(state, { request, response, instruction, expect }) {
     const ASSET_CODE = Config.get("ASSET_CODE");
     const USER_SK = Config.get("USER_SK");
@@ -15,14 +15,21 @@ module.exports = {
       asset_code: ASSET_CODE,
       account: pk,
     };
-    request("GET /withdraw", params);
-    // Expect this to fail with 403
-    const result = await get(`${transfer_server}/withdraw`, params, {
-      headers: {
-        Authorization: `Bearer ${state.token}`,
+    request("POST /transactions/withdraw/interactive", params);
+    const searchParams = new URLSearchParams();
+    Object.keys(params).forEach((key) => searchParams.append(key, params[key]));
+    const resp = await fetch(
+      `${transfer_server}/transactions/withdraw/interactive`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${state.token}`,
+        },
+        body: searchParams,
       },
-    });
-    response("GET /withdraw", result);
+    );
+    const result = await resp.json();
+    response("POST /transactions/withdraw/interactive", result);
     expect(
       result.type == "interactive_customer_info_needed",
       "The only supported type is interactive_customer_info_needed",

--- a/src/steps/withdraw/show_interactive_webapp.js
+++ b/src/steps/withdraw/show_interactive_webapp.js
@@ -13,10 +13,6 @@ module.exports = {
       // Add the parent_url so we can use postMessage inside the webapp
       const urlBuilder = new URL(state.interactive_url);
       urlBuilder.searchParams.set("jwt", state.token);
-      const email = Config.get("EMAIL_ADDRESS");
-      if (email) {
-        urlBuilder.searchParams.set("email_address", email);
-      }
       const url = urlBuilder.toString();
       action(
         `Launching interactive webapp at ${url} and watching for postMessage callback`,


### PR DESCRIPTION
In stellar/stellar-protocol#438 we change the /deposit and /withdraw endpoints to new URLs and change them to POST instead of GET for security. This makes the changes specified in that PR.

Changes /deposit to /transactions/deposit/interactive
Changes /withdraw to /transactions/withdraw/interactive
Changes both endpoints to POST

Land with https://github.com/stellar/stellar-anchor-server/pull/157