### PR TITLE
Fix hash memo length on deposit (32 bytes, not 64)

### DIFF
--- a/src/steps/deposit/get_deposit.js
+++ b/src/steps/deposit/get_deposit.js
@@ -13,7 +13,7 @@ module.exports = {
     const pk = StellarSDK.Keypair.fromSecret(USER_SK).publicKey();
     const transfer_server = state.transfer_server;
 
-    state.deposit_memo = crypto.randomBytes(64).toString("base64");
+    state.deposit_memo = crypto.randomBytes(32).toString("base64");
     state.deposit_memo_type = "hash";
     instruction(
       `We've created the deposit memo ${state.deposit_memo} to listen for a successful deposit`,


### PR DESCRIPTION
Hash memos are 32 bytes:
https://www.stellar.org/developers/guides/concepts/transactions.html#memo

get_deposit.js was incorrectly generating 64-byte hashes.

/cc @tomerweller 