### PR TITLE
Add a happy path test for /transactions endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const StellarSdk = require("stellar-sdk");
  * @property {string} transaction_id - Anchor identifier for transaction
  *
  * Withdraw
+ * @property {string} begin_time - UTC ISO 8601 time that the SEP-24 transaction was kicked off
  * @property {string} anchors_stellar_address - Address that the anchor will be expecting payment on for the in-flight transaction
  * @property {string} stellar_memo_type - Memo type for the stellar transaction to specify the anchor's transaction
  * @property {string} stellar_memo - Memo required for the specified stellar transaction
@@ -41,7 +42,9 @@ const StellarSdk = require("stellar-sdk");
 /**
  * @type State
  */
-const state = {};
+const state = {
+  begin_time: new Date().toISOString(),
+};
 
 Config.listen(() => {
   const disclaimer = document.getElementById("pubnet-disclaimer");
@@ -74,6 +77,7 @@ const withdrawSteps = [
   require("./steps/SEP10/sign"),
   require("./steps/SEP10/send"),
   require("./steps/withdraw/get_withdraw"),
+  require("./steps/withdraw/check_transactions_endpoint"),
   require("./steps/withdraw/show_interactive_webapp"),
   require("./steps/withdraw/confirm_payment"),
   require("./steps/withdraw/send_stellar_transaction"),

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,7 @@ const depositSteps = [
   require("./steps/SEP10/sign"),
   require("./steps/SEP10/send"),
   require("./steps/deposit/get_deposit"),
+  require("./steps/withdraw/check_transactions_endpoint"),
   require("./steps/deposit/show_interactive_webapp"),
   require("./steps/deposit/show_close_button"),
   // require("./steps/deposit/show_deposit_info"),

--- a/src/steps/withdraw/check_transactions_endpoint.js
+++ b/src/steps/withdraw/check_transactions_endpoint.js
@@ -11,32 +11,36 @@ module.exports = {
     const USER_SK = Config.get("USER_SK");
     const pk = StellarSDK.Keypair.fromSecret(USER_SK).publicKey();
     const transfer_server = state.transfer_server;
-    const url = `${transfer_server}/transactions?asset_code=${ASSET_CODE}&account=${pk}&no_older_than=${state.begin_time}`;
+    const url = `${transfer_server}/transactions?asset_code=${ASSET_CODE}&no_older_than=${state.begin_time}`;
     request("GET " + url);
-    const transactionResponse = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${state.token}`,
-      },
-    });
-    expect(
-      transactionResponse.status === 200,
-      `/transactions responded with status code ${transactionResponse.status}`,
-    );
-    const transactionsResult = await transactionResponse.json();
-    response("GET /transactions", transactionsResult);
-    expect(
-      !transactionsResult.error,
-      `Transactions list had error: ${transactionsResult.error}`,
-    );
-    expect(
-      transactionsResult.transactions &&
-        transactionsResult.transactions.length > 0,
-      "There are no transactions returned, there should be at least the one we just created",
-    );
-    expect(
-      transactionsResult.transactions &&
-        transactionsResult.transactions.length < 2,
-      "There should be 1 and only 1 transaction available since this transaction started.  Perhaps the `no_older_than` flag isn't being respected.",
-    );
+    try {
+      const transactionResponse = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${state.token}`,
+        },
+      });
+      expect(
+        transactionResponse.status === 200,
+        `/transactions responded with status code ${transactionResponse.status}`,
+      );
+      const transactionsResult = await transactionResponse.json();
+      response("GET /transactions", transactionsResult);
+      expect(
+        !transactionsResult.error,
+        `Transactions list had error: ${transactionsResult.error}`,
+      );
+      expect(
+        transactionsResult.transactions &&
+          transactionsResult.transactions.length > 0,
+        "There are no transactions returned, there should be at least the one we just created",
+      );
+      expect(
+        transactionsResult.transactions &&
+          transactionsResult.transactions.length < 2,
+        "There should be 1 and only 1 transaction available since this transaction started.  Perhaps the `no_older_than` flag isn't being respected.",
+      );
+    } catch (e) {
+      expect(false, "Something went wrong fetching /transactions");
+    }
   },
 };

--- a/src/steps/withdraw/check_transactions_endpoint.js
+++ b/src/steps/withdraw/check_transactions_endpoint.js
@@ -11,21 +11,19 @@ module.exports = {
     const USER_SK = Config.get("USER_SK");
     const pk = StellarSDK.Keypair.fromSecret(USER_SK).publicKey();
     const transfer_server = state.transfer_server;
-    request("GET /transactions");
-    const transactionResponse = await fetch(
-      `${transfer_server}/transactions?asset_code=${ASSET_CODE}&account=${pk}&no_older_than=${state.begin_time}`,
-      {
-        headers: {
-          Authorization: `Bearer ${state.token}`,
-        },
+    const url = `${transfer_server}/transactions?asset_code=${ASSET_CODE}&account=${pk}&no_older_than=${state.begin_time}`;
+    request("GET " + url);
+    const transactionResponse = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${state.token}`,
       },
-    );
+    });
     expect(
       transactionResponse.status === 200,
       `/transactions responded with status code ${transactionResponse.status}`,
     );
     const transactionsResult = await transactionResponse.json();
-    response("GET /transaction", transactionsResult);
+    response("GET /transactions", transactionsResult);
     expect(
       !transactionsResult.error,
       `Transactions list had error: ${transactionsResult.error}`,

--- a/src/steps/withdraw/check_transactions_endpoint.js
+++ b/src/steps/withdraw/check_transactions_endpoint.js
@@ -1,0 +1,44 @@
+const StellarSDK = require("stellar-sdk");
+const Config = require("src/config");
+const get = require("src/util/get");
+
+module.exports = {
+  instruction:
+    "Check to ensure this new transaction shows up in the transactions list",
+  action: "GET /transactions (SEP-0024)",
+  execute: async function(state, { request, response, instruction, expect }) {
+    const ASSET_CODE = Config.get("ASSET_CODE");
+    const USER_SK = Config.get("USER_SK");
+    const pk = StellarSDK.Keypair.fromSecret(USER_SK).publicKey();
+    const transfer_server = state.transfer_server;
+    request("GET /transactions");
+    const transactionResponse = await fetch(
+      `${transfer_server}/transactions?asset_code=${ASSET_CODE}&account=${pk}&no_older_than=${state.begin_time}`,
+      {
+        headers: {
+          Authorization: `Bearer ${state.token}`,
+        },
+      },
+    );
+    expect(
+      transactionResponse.status === 200,
+      `/transactions responded with status code ${transactionResponse.status}`,
+    );
+    const transactionsResult = await transactionResponse.json();
+    response("GET /transaction", transactionsResult);
+    expect(
+      !transactionsResult.error,
+      `Transactions list had error: ${transactionsResult.error}`,
+    );
+    expect(
+      transactionsResult.transactions &&
+        transactionsResult.transactions.length > 0,
+      "There are no transactions returned, there should be at least the one we just created",
+    );
+    expect(
+      transactionsResult.transactions &&
+        transactionsResult.transactions.length < 2,
+      "There should be 1 and only 1 transaction available since this transaction started.  Perhaps the `no_older_than` flag isn't being respected.",
+    );
+  },
+};


### PR DESCRIPTION
We need to verify that the `/transactions` endpoint returns correctly.  This tests after the initial `POST /transaction/withdraw/interactive` and deposit endpoints to ensure there is one and only one transaction thats been created for this account since we started. 

It's only a happy path test.  Full spec validation will be part of the validator project.  If there's things that would be useful to test immediately here lmk.

Fixes #124 