### PR TITLE
add StrictMode

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -34,6 +34,12 @@ let fields = [
     optional: true,
   },
   {
+    key: "STRICT_MODE",
+    label: "Strict Mode: Abort the flow when an error is thrown",
+    value: true,
+    type: "checkbox",
+  },
+  {
     key: "AUTO_ADVANCE",
     label: "Automatically perform background operations",
     value: false,
@@ -68,12 +74,14 @@ const load = () => {
     .split("&")
     .map((entry) => entry.split("="))
     .reduce((obj, val) => {
+      console.log("VAL", val[0], val[1]);
       obj[val[0]] = val[1];
       return obj;
     }, {});
 
   fields.forEach((field) => {
     let hashValue = hashFields[field.key];
+    if (hashValue === undefined) hashValue = field.value;
     if (hashValue) hashValue = JSON.parse(decodeURI(hashValue));
     // Prefer query param but fall back to local storage
     field.value =

--- a/src/config.js
+++ b/src/config.js
@@ -74,14 +74,12 @@ const load = () => {
     .split("&")
     .map((entry) => entry.split("="))
     .reduce((obj, val) => {
-      console.log("VAL", val[0], val[1]);
       obj[val[0]] = val[1];
       return obj;
     }, {});
 
   fields.forEach((field) => {
     let hashValue = hashFields[field.key];
-    if (hashValue === undefined) hashValue = field.value;
     if (hashValue) hashValue = JSON.parse(decodeURI(hashValue));
     // Prefer query param but fall back to local storage
     field.value =

--- a/src/index.js
+++ b/src/index.js
@@ -121,7 +121,6 @@ const runStep = (step) => {
     uiActions.finish();
     return;
   }
-
   uiActions.instruction(step.instruction);
   currentStep = step;
   if (Config.get("AUTO_ADVANCE") || step.autoStart) next();

--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,7 @@ const runStep = (step) => {
     uiActions.finish();
     return;
   }
+
   uiActions.instruction(step.instruction);
   currentStep = step;
   if (Config.get("AUTO_ADVANCE") || step.autoStart) next();

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -3,7 +3,7 @@
   background-image: url("./assets/next-arrow.svg");
   background-position: 20px center;
 
-  &:not(.loading) {
+  &:not(.loading):not(.failed) {
     animation: pulse 1.5s infinite;
     animation-delay: 0.5s;
   }
@@ -11,6 +11,11 @@
   &:hover {
     animation: none;
     cursor: pointer;
+  }
+
+  &.failed {
+    background: $red;
+    padding-left: 42px;
   }
 
   &.loading {

--- a/src/ui/ui-actions.js
+++ b/src/ui/ui-actions.js
@@ -1,3 +1,5 @@
+const Config = require("../config");
+
 const Renderjson = require("renderjson");
 Renderjson.set_show_to_level(1);
 
@@ -56,7 +58,17 @@ const response = (message, params) => {
   logObject(message, params, "incoming");
 };
 
+let isFailed = false;
+const setFailed = () => {
+  actionButton.disabled = true;
+  actionButton.textContent = "Failed";
+  actionButton.classList.remove("loading");
+  actionButton.classList.add("failed");
+  isFailed = true;
+};
+
 const setLoading = (loading, loadingMessage) => {
+  if (isFailed) return;
   if (loading) {
     actionButton.textContent = loadingMessage || "Waiting...";
     actionButton.disabled = true;
@@ -117,6 +129,7 @@ const waitForPageMessage = (src) => {
 
 const error = (message) => {
   addEntry(message, "error");
+  if (Config.get("STRICT_MODE")) setFailed();
 };
 
 const onNext = (cb) => actionButton.addEventListener("click", cb);
@@ -132,6 +145,7 @@ module.exports = {
 
   onNext,
   setLoading,
+  setFailed,
   finish,
 
   showConfig,


### PR DESCRIPTION
Add a strict mode to the demo client which will stop the flow when an error is thrown, instead of the current behavior that lets people continue on after throwing a non-fatal error.

Fixes #141 