### PR TITLE
Use FormData instead of urlencoded for POST endpoints

### DIFF
--- a/src/steps/deposit/get_deposit.js
+++ b/src/steps/deposit/get_deposit.js
@@ -28,8 +28,8 @@ module.exports = {
       params.email_address = email;
     }
     request("POST /transactions/deposit/interactive", params);
-    const searchParams = new URLSearchParams();
-    Object.keys(params).forEach((key) => searchParams.append(key, params[key]));
+    const formData = new FormData();
+    Object.keys(params).forEach((key) => formData.append(key, params[key]));
     const resp = await fetch(
       `${transfer_server}/transactions/deposit/interactive`,
       {
@@ -37,7 +37,7 @@ module.exports = {
         headers: {
           Authorization: `Bearer ${state.token}`,
         },
-        body: searchParams,
+        body: formData,
       },
     );
     const result = await resp.json();

--- a/src/steps/withdraw/get_withdraw.js
+++ b/src/steps/withdraw/get_withdraw.js
@@ -20,8 +20,8 @@ module.exports = {
       params.email_address = email;
     }
     request("POST /transactions/withdraw/interactive", params);
-    const searchParams = new URLSearchParams();
-    Object.keys(params).forEach((key) => searchParams.append(key, params[key]));
+    const formData = new FormData();
+    Object.keys(params).forEach((key) => formData.append(key, params[key]));
     const resp = await fetch(
       `${transfer_server}/transactions/withdraw/interactive`,
       {
@@ -29,7 +29,7 @@ module.exports = {
         headers: {
           Authorization: `Bearer ${state.token}`,
         },
-        body: searchParams,
+        body: formData,
       },
     );
     const result = await resp.json();


### PR DESCRIPTION
Fixes #144 

In the POST deposit/withdraw endpoints we were using URLSearchParams which serializes out to x-www-urlencoded content type.  Instead we can use FormData, which serializes to multipart/form-data content type.