### PR TITLE
Use postmessage callacks in url

### DIFF
--- a/src/steps/deposit/show_interactive_webapp.js
+++ b/src/steps/deposit/show_interactive_webapp.js
@@ -13,6 +13,7 @@ module.exports = {
       // Add the parent_url so we can use postMessage inside the webapp
       const urlBuilder = new URL(state.interactive_url);
       urlBuilder.searchParams.set("jwt", state.token);
+      urlBuilder.searchParams.set("callback", "postMessage");
       const url = urlBuilder.toString();
       action(
         `Launching interactive webapp at ${url} and watching for postMessage callback`,

--- a/src/steps/withdraw/show_interactive_webapp.js
+++ b/src/steps/withdraw/show_interactive_webapp.js
@@ -13,6 +13,7 @@ module.exports = {
       // Add the parent_url so we can use postMessage inside the webapp
       const urlBuilder = new URL(state.interactive_url);
       urlBuilder.searchParams.set("jwt", state.token);
+      urlBuilder.searchParams.set("callback", "postMessage");
       const url = urlBuilder.toString();
       action(
         `Launching interactive webapp at ${url} and watching for postMessage callback`,


### PR DESCRIPTION
When opening the interactive webapp, we need to pass a `callback` parameter.  Since the demo client doesn't have a backend, we can only use the postMessage callback , so we append `callback=postMessage`, letting the anchors know that's how we wish to be called back.