### PR TITLE
Check that the schema of the transaction object is proper

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
     "@stellar/prettier-config": "^1.0.1",
     "dotenv": "^8.0.0",
     "dotenv-webpack": "^1.7.0",
+    "jsonschema": "^1.2.5",
     "lodash.get": "^4.4.2",
     "node-sass": "^4.12.0",
     "renderjson": "^1.4.0",
-    "toml": "^3.0.0",
     "sass-loader": "^7.2.0",
-    "stellar-sdk": "^2.1.1"
+    "stellar-sdk": "^2.1.1",
+    "toml": "^3.0.0"
   },
   "husky": {
     "hooks": {

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,0 +1,60 @@
+const TransactionSchema = {
+  type: "object",
+  properties: {
+    transaction: {
+      type: "object",
+      properties: {
+        id: { type: "string" },
+        kind: { type: "string", pattern: "deposit|withdraw" },
+        status: {
+          type: "string",
+          pattern:
+            "completed|pending_external|pending_anchor|pending_stellar|pending_trust|pending_user|pending_user_transfer_start|incomplete|no_market|too_small|too_large|error",
+        },
+        more_info_url: {
+          type: "string",
+          format: "uri",
+        },
+        status_eta: {
+          type: "number",
+        },
+        amount_in: {
+          type: ["string", "null"],
+        },
+        amount_out: {
+          type: ["string", "null"],
+        },
+        amount_fee: {
+          type: ["string", "null"],
+        },
+        started_at: {
+          type: "string",
+          format: "date-time",
+        },
+        completed_at: {
+          type: ["string", "null"],
+          format: "date-time",
+        },
+        stellar_transaction_id: {
+          type: ["string", "null"],
+          pattern: "G[A-Z0-9]{55}",
+        },
+        external_transaction_id: {
+          type: ["string", "null"],
+        },
+        message: {
+          type: ["string", "null"],
+        },
+        refunded: {
+          type: "boolean",
+        },
+      },
+      required: ["id", "kind", "status", "more_info_url"],
+    },
+  },
+  required: ["transaction"],
+};
+
+module.exports = {
+  TransactionSchema,
+};

--- a/src/steps/deposit/show_interactive_webapp.js
+++ b/src/steps/deposit/show_interactive_webapp.js
@@ -1,5 +1,7 @@
 const Config = require("src/config");
 const StellarSdk = require("stellar-sdk");
+const TransactionSchema = require("../../schema").TransactionSchema;
+const validate = require("jsonschema").validate;
 
 module.exports = {
   instruction:
@@ -49,6 +51,11 @@ module.exports = {
             expect(
               transaction.id,
               "postMessage callback transaction contains no id",
+            );
+            const validation = validate({ transaction }, TransactionSchema);
+            expect(
+              validation.valid,
+              "Transaction is not in the right schema: " + validation.errors,
             );
             const urlBuilder = new URL(transaction.more_info_url);
             urlBuilder.searchParams.set("jwt", state.token);

--- a/src/steps/withdraw/poll_for_success.js
+++ b/src/steps/withdraw/poll_for_success.js
@@ -1,5 +1,7 @@
 const get = require("src/util/get");
 const Config = require("src/config");
+const TransactionSchema = require("../../schema").TransactionSchema;
+const validate = require("jsonschema").validate;
 
 // TODO should this poll?
 module.exports = {
@@ -26,6 +28,11 @@ module.exports = {
           },
         );
         response("GET /transaction", transactionResult);
+        const validation = validate(transactionResult, TransactionSchema);
+        expect(
+          validation.valid,
+          "Transaction is not in the right schema: " + validation.errors,
+        );
         if (transactionResult.transaction.status === "completed") {
           expect(
             transactionResult.transaction.external_transaction_id ||

--- a/src/steps/withdraw/show_interactive_webapp.js
+++ b/src/steps/withdraw/show_interactive_webapp.js
@@ -1,5 +1,7 @@
 const Config = require("src/config");
 const StellarSdk = require("stellar-sdk");
+const validate = require("jsonschema").validate;
+const TransactionSchema = require("../../schema").TransactionSchema;
 
 module.exports = {
   instruction:
@@ -51,15 +53,17 @@ module.exports = {
             transaction.withdraw_memo_type,
             "withdraw_memo_type undefined in postMessage callback.",
           );
+          expect(transaction.id, "id is undefined in postMessage callback.");
+          const validation = validate({ transaction }, TransactionSchema);
           expect(
-            transaction.id,
-            "id is undefined in postMessage callback.  Falling back to using memo as ID, but this will be removed shortly.  Please send an explicit id field.",
+            validation.valid,
+            "Transaction is not in the right schema: " + validation.errors,
           );
           state.anchors_stellar_address = transaction.withdraw_anchor_account;
           state.stellar_memo = transaction.withdraw_memo;
           state.stellar_memo_type = transaction.withdraw_memo_type;
           state.withdraw_amount = transaction.amount_in;
-          state.transaction_id = transaction.id || state.stellar_memo;
+          state.transaction_id = transaction.id;
           window.removeEventListener("message", cb);
           popup.close();
           resolve();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,6 +2686,11 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
+jsonschema@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.5.tgz#bab69d97fa28946aec0a56a9cc266d23fe80ae61"
+  integrity sha512-kVTF+08x25PQ0CjuVc0gRM9EUPb0Fe9Ln/utFOgcdxEIOHuU7ooBk/UPTd7t1M91pP35m0MU1T8M5P7vP1bRRw==
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"


### PR DESCRIPTION
Fixes #124 

Use the Schema created for the automated validation suite to ensure the Transaction objects are the right shape in various points of the flow.  Show the validation error when that's not the case.

Also removed some loosened requirements that we were allowing for an early anchor.