### PR TITLE
Use client-generated memo for withdraw flow

### DIFF
--- a/src/steps/withdraw/get_withdraw.js
+++ b/src/steps/withdraw/get_withdraw.js
@@ -11,9 +11,13 @@ module.exports = {
     const USER_SK = Config.get("USER_SK");
     const pk = StellarSDK.Keypair.fromSecret(USER_SK).publicKey();
     const transfer_server = state.transfer_server;
+    state.stellar_memo = crypto.randomBytes(32);
+    state.stellar_memo_type = "hash";
     const params = {
       asset_code: ASSET_CODE,
       account: pk,
+      memo: state.stellar_memo.toString("base64"),
+      memo_type: state.stellar_memo_type,
     };
     const email = Config.get("EMAIL_ADDRESS");
     if (email) {

--- a/src/steps/withdraw/get_withdraw.js
+++ b/src/steps/withdraw/get_withdraw.js
@@ -1,6 +1,7 @@
 const StellarSDK = require("stellar-sdk");
 const Config = require("src/config");
 const get = require("src/util/get");
+const crypto = require("crypto");
 
 module.exports = {
   instruction:

--- a/src/steps/withdraw/send_stellar_transaction.js
+++ b/src/steps/withdraw/send_stellar_transaction.js
@@ -13,7 +13,7 @@ module.exports = {
     const pk = StellarSdk.Keypair.fromSecret(USER_SK).publicKey();
     request("Sending the payment using the following anchor account info", {
       address: state.anchors_stellar_address,
-      memo: state.stellar_memo,
+      memo: state.stellar_memo.toString("hex"),
       memo_type: state.stellar_memo_type,
     });
     const server = new StellarSdk.Server(HORIZON_URL);
@@ -36,7 +36,7 @@ module.exports = {
         id: StellarSdk.Memo.id,
         hash: StellarSdk.Memo.hash,
       }[state.stellar_memo_type];
-      memo = memoType(state.stellar_memo);
+      memo = memoType(state.stellar_memo.toString("hex"));
     } catch (e) {
       expect(
         false,

--- a/src/steps/withdraw/show_interactive_webapp.js
+++ b/src/steps/withdraw/show_interactive_webapp.js
@@ -55,8 +55,6 @@ module.exports = {
             "id is undefined in postMessage callback.  Falling back to using memo as ID, but this will be removed shortly.  Please send an explicit id field.",
           );
           state.anchors_stellar_address = transaction.withdraw_anchor_account;
-          state.stellar_memo = transaction.withdraw_memo;
-          state.stellar_memo_type = transaction.withdraw_memo_type;
           state.withdraw_amount = transaction.amount_in;
           state.transaction_id =
             transaction.id || state.stellar_memo.toString("hex");

--- a/src/steps/withdraw/show_interactive_webapp.js
+++ b/src/steps/withdraw/show_interactive_webapp.js
@@ -58,7 +58,8 @@ module.exports = {
           state.stellar_memo = transaction.withdraw_memo;
           state.stellar_memo_type = transaction.withdraw_memo_type;
           state.withdraw_amount = transaction.amount_in;
-          state.transaction_id = transaction.id || state.stellar_memo;
+          state.transaction_id =
+            transaction.id || state.stellar_memo.toString("hex");
           window.removeEventListener("message", cb);
           popup.close();
           resolve();


### PR DESCRIPTION
Previously we were assuming the anchor would generate a memo for us, which isn't part of the SEP but Polaris was doing it. This change makes the withdraw flow similar to the deposit flow by sending a random memo to the anchor.